### PR TITLE
Fix wrongly assigned default value to the file_config

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,7 @@
 locals {
   # === CONFIG file parsing ===
 
-  file_config = try(yamldecode(file(var.config))["config"], {})
+  file_config = try(yamldecode(file(var.config))["config"], [])
   raw_config  = yamldecode(var.raw_config)["config"]
   # Overwrite configurations (if applicable)
   config = length(local.raw_config) > 0 ? local.raw_config : local.file_config


### PR DESCRIPTION
## Description

Fixing bug affecting default local file configuration value assigned when nothing was provided.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Terraform format test (Workflow)
- [ ] Replace this with any custom tests (if applicable)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
